### PR TITLE
Autofocus search field upon page load

### DIFF
--- a/components/_search/SearchForm.tsx
+++ b/components/_search/SearchForm.tsx
@@ -8,6 +8,10 @@ type Props = {
 const SearchForm = ({ onSearch }: Props) => {
   const [autocomplete, setAutocomplete] = useState(null);
   const searchFormRef = useRef();
+  
+  useEffect(() => {
+    ($('#search_form_input' as any).focus()
+  }, [])
 
   const handlePackageSelection = useCallback(
     (packageName: string) => {


### PR DESCRIPTION
Suggestion: maybe it could autofocus the search input upon page load. Caveat: I haven't tested this, just figured this PR was more expedient than opening an issue.