### PR TITLE
Add support for third party API env vars

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@
 # misc
 .DS_Store
 *.pem
+.idea
 
 # debug
 npm-debug.log*

--- a/services/Package.ts
+++ b/services/Package.ts
@@ -1,7 +1,7 @@
 import { get as _get } from 'lodash';
 import hostedGitInfo from 'hosted-git-info';
 
-import { urlWithProxy } from 'utils/proxy';
+import { githubReposURL, npmRegistryURL, npmsPackageURL } from 'utils/proxy';
 import { colors } from 'utils/colors';
 import IPackage from 'types/IPackage';
 import INpmRegistryDataFormatted from 'types/INpmRegistryDataFormatted';
@@ -74,7 +74,7 @@ class Package {
   };
 
   static fetchPackageFromNpms = async (packageName: string): Promise<IPackage> => {
-    const url = `https://api.npms.io/v2/package/${encodeURIComponent(encodeURIComponent(packageName))}`;
+    const url = npmsPackageURL(encodeURIComponent(packageName));
 
     const fetchRegistryData = async () => {
       try {
@@ -86,7 +86,7 @@ class Package {
     };
 
     const [npmsPackageData, npmRegistryDataFormatted] = await Promise.all([
-      Fetch.getJSON(urlWithProxy(url)),
+      Fetch.getJSON(url),
       fetchRegistryData(),
     ]);
 
@@ -175,10 +175,7 @@ class Package {
   static fetchGithubRepo = async (url: string) => {
     try {
       const repositoryPath = url.split('.com')[1].replace('.git', '');
-
-      const githubUrl = `https://api.github.com/repos${repositoryPath}`;
-
-      return await Fetch.getJSON(urlWithProxy(githubUrl));
+      return await Fetch.getJSON(githubReposURL(repositoryPath));
     } catch (e) {
       console.error('Problem fetching GitHub data', e);
       return {};
@@ -186,9 +183,8 @@ class Package {
   };
 
   static fetchNpmRegistryData = async (packetName: string): Promise<any> => {
-    const url = `https://registry.npmjs.org/${encodeURIComponent(packetName)}`;
-
-    return Fetch.getJSON(urlWithProxy(url));
+    const url = npmRegistryURL(encodeURIComponent(packetName));
+    return Fetch.getJSON(url);
   };
 }
 

--- a/services/PackageDownloads.ts
+++ b/services/PackageDownloads.ts
@@ -1,7 +1,7 @@
 import moment from 'moment';
 
+import { npmDownloadsURL } from 'utils/proxy';
 import Fetch from './Fetch';
-import { urlWithProxy } from 'utils/proxy';
 
 class PackageDownloads {
   static fetchDownloads = async (packageName, startDate, endDate) => {
@@ -41,13 +41,13 @@ class PackageDownloads {
   };
 
   static fetchFromApi = async (packageName, period): Promise<any> => {
-    const url = `https://api.npmjs.org/downloads/range/${period}/${packageName}`;
-    return Fetch.getJSON(urlWithProxy(url));
+    const url = npmDownloadsURL(`range/${period}/${packageName}`);
+    return Fetch.getJSON(url);
   };
 
   static fetchPoint = async (packageName, period = 'last-month'): Promise<any> => {
-    const url = `https://api.npmjs.org/downloads/point/${period}/${packageName}`;
-    return Fetch.getJSON(urlWithProxy(url));
+    const url = npmDownloadsURL(`point/${period}/${packageName}`);
+    return Fetch.getJSON(url);
   };
 }
 

--- a/utils/proxy.ts
+++ b/utils/proxy.ts
@@ -1,3 +1,46 @@
-const proxyUrl = process.env.NEXT_PUBLIC_PROXY_URL;
+/* eslint-disable prefer-destructuring */
+// Why no destructuring? See: https://github.com/vercel/next.js/issues/19420
+const PROXY_URL = process.env.NEXT_PUBLIC_PROXY_URL;
+const GITHUB_REPOS_API_ENDPOINT = process.env.NEXT_PUBLIC_GITHUB_REPOS_API_ENDPOINT;
+const NPM_DOWNLOADS_API_ENDPOINT = process.env.NEXT_PUBLIC_NPM_DOWNLOADS_API_ENDPOINT;
+const NPM_REGISTRY_API_ENDPOINT = process.env.NEXT_PUBLIC_NPM_REGISTRY_API_ENDPOINT;
+const NPMS_PACKAGE_API_ENDPOINT = process.env.NEXT_PUBLIC_NPMS_PACKAGE_API_ENDPOINT;
 
-export const urlWithProxy = (url) => `${proxyUrl}/?url=${url}`;
+export const urlWithProxy = (url) => {
+    if (PROXY_URL) {
+        return `${PROXY_URL}/?url=${url}`;
+    }
+    return url;
+};
+
+// See: https://docs.github.com/en/rest/repos/repos#get-a-repository
+export const githubReposURL = (path) => {
+    if (GITHUB_REPOS_API_ENDPOINT) {
+        return `${GITHUB_REPOS_API_ENDPOINT}/${path}`;
+    }
+    return urlWithProxy(`https://api.github.com/repos/${path}`);
+};
+
+// See: https://github.com/npm/registry/blob/cfe04736f34db9274a780184d1cdb2fb3e4ead2a/docs/download-counts.md
+export const npmDownloadsURL = (path) => {
+    if (NPM_DOWNLOADS_API_ENDPOINT) {
+        return `${NPM_DOWNLOADS_API_ENDPOINT}/${path}`;
+    }
+    return urlWithProxy(`https://api.npmjs.org/downloads/${path}`);
+};
+
+// See: https://github.com/npm/registry/blob/cfe04736f34db9274a780184d1cdb2fb3e4ead2a/docs/REGISTRY-API.md#package-endpoints
+export const npmRegistryURL = (path) => {
+    if (NPM_REGISTRY_API_ENDPOINT) {
+        return `${NPM_REGISTRY_API_ENDPOINT}/${path}`;
+    }
+    return urlWithProxy(`https://registry.npmjs.org/${path}`);
+};
+
+// See: https://api-docs.npms.io/#api-Package
+export const npmsPackageURL = (path) => {
+    if (NPMS_PACKAGE_API_ENDPOINT) {
+        return `${NPMS_PACKAGE_API_ENDPOINT}/${path}`;
+    }
+    return urlWithProxy(`https://api.npms.io/v2/package/${path}`);
+};


### PR DESCRIPTION
We recently added endpoints to the nginx API gateway (https://npm-trends-gateway.onrender.com/) that can proxy (and cache) requests to various third-party APIs:

```
location /npm/downloads/ {
    proxy_cache main;
    add_header X-Proxy-Cache $upstream_cache_status;

    proxy_pass https://api.npmjs.org/downloads/;
}

location /npm/registry/ {
    proxy_cache main;
    add_header X-Proxy-Cache $upstream_cache_status;

    proxy_pass https://registry.npmjs.org/;
}

location /github/repos/ {
    proxy_cache main;
    add_header X-Proxy-Cache $upstream_cache_status;

    proxy_pass https://api.github.com/repos/;
}
```

This change allows the UI to use these API gateway endpoints when configured and fall back to the proxy otherwise.