### PR TITLE
Fix install size badge

### DIFF
--- a/components/_statsTable/PackageStats/_components/BundlephobiaRenderer.tsx
+++ b/components/_statsTable/PackageStats/_components/BundlephobiaRenderer.tsx
@@ -5,26 +5,27 @@ const propTypes = {
   packet: PropTypes.object,
 };
 
-const BundlephobiaRenderer = ({ packet }) => {
+const PackagephobiaRenderer = ({ packet }) => {
   const [hideSize, setHideSize] = useState(false);
 
   if (hideSize) return null;
 
-  const sizeUrl = `https://bundlephobia.com/result?p=${packet.name}`;
+  const sizeUrl = `https://packagephobia.com/result?p=${packet.name}`;
+  const badgeUrl = `https://packagephobia.com/badge?p=${packet.name}`;
   return (
     <a href={sizeUrl} target="_blank" rel="noopener noreferrer">
       <img
         width={146}
         height={20}
         onError={() => setHideSize(true)}
-        src={`https://flat.badgen.net/bundlephobia/minzip/${packet.name}`}
-        alt={`Minified + gzip package size for ${packet.name} in KB`}
+        src={badgeUrl}
+        alt={`Install size for ${packet.name}, including dependencies`}
         className="badge--in-table"
       />
     </a>
   );
 };
 
-BundlephobiaRenderer.propTypes = propTypes;
+PackagephobiaRenderer.propTypes = propTypes;
 
-export default BundlephobiaRenderer;
+export default PackagephobiaRenderer;

--- a/components/_statsTable/PackageStats/index.tsx
+++ b/components/_statsTable/PackageStats/index.tsx
@@ -5,7 +5,7 @@ import DetailsPopover from 'components/_components/_popovers/DetailsPopover';
 import PackageLinks from 'components/_components/PackageLinks';
 import Tooltip from 'components/_components/Tooltip';
 import PackageStatsRow from './_components/PackageStatsRow';
-import BundlephobiaRenderer from './_components/BundlephobiaRenderer';
+import PackagephobiaRenderer from './_components/PackagephobiaRenderer';
 import styles from './PackageStats.module.scss';
 
 dayjs.extend(relativeTime);
@@ -66,7 +66,7 @@ const columns = [
     renderer: (packet: IPackage) =>
       packet.createdDate ? dayjs(packet.createdDate).fromNow() : <i aria-hidden className="icon icon-dash" />,
   },
-  { heading: 'Size', renderer: (packet: IPackage) => <BundlephobiaRenderer packet={packet} /> },
+  { heading: 'Size', renderer: (packet: IPackage) => <PackagephobiaRenderer packet={packet} /> },
 ];
 
 type Props = {


### PR DESCRIPTION
The current badge is using https://bundlephobia.com and returns 429.

<img width="338" alt="image" src="https://user-images.githubusercontent.com/229881/179514580-c909d488-34ef-4a9d-b889-d884d339a1bc.png">

Likely because the bundle size can't be computed for most npm packages since most are not designed for the browser.

This PR switches the Install Size badge to use https://packagephobia.com which will display the proper npm install size.
