### PR TITLE
Feature:Relative Growth Rate

### DIFF
--- a/components/_chart/TrendGraph.tsx
+++ b/components/_chart/TrendGraph.tsx
@@ -7,10 +7,10 @@ import { groupDownloadsByPeriod } from 'utils/groupDates';
 type Props = {
   graphStats: any[];
   colors: number[][];
-  relativeGrowth: boolean;
+  growth: boolean;
 };
 
-const TrendGraph = ({ graphStats, colors, relativeGrowth }: Props) => {
+const TrendGraph = ({ graphStats, colors, growth }: Props) => {
   const stats = graphStats?.filter(Boolean);
   const chartInstance = useRef(null);
 
@@ -18,7 +18,7 @@ const TrendGraph = ({ graphStats, colors, relativeGrowth }: Props) => {
     const chartData = { labels: [], datasets: [] };
     stats.filter(Boolean).forEach((graphStat, i) => {
       const dataColor = colors[i].join(',');
-      const groupedData = groupDownloadsByPeriod(graphStat.downloads, 'week', relativeGrowth);
+      const groupedData = groupDownloadsByPeriod(graphStat.downloads, 'week', growth);
 
       if (i === 0) {
         const labels = groupedData.map((periodData) => periodData.period);
@@ -104,7 +104,7 @@ const TrendGraph = ({ graphStats, colors, relativeGrowth }: Props) => {
           {
             ticks: {
               beginAtZero: true,
-              callback: (value) => `${Number(value).toLocaleString()}${relativeGrowth ? ' %' : ''}`,
+              callback: (value) => `${Number(value).toLocaleString()}${growth ? ' %' : ''}`,
             },
           },
         ],

--- a/components/_chart/TrendGraph.tsx
+++ b/components/_chart/TrendGraph.tsx
@@ -7,9 +7,10 @@ import { groupDownloadsByPeriod } from 'utils/groupDates';
 type Props = {
   graphStats: any[];
   colors: number[][];
+  relativeGrowth: boolean;
 };
 
-const TrendGraph = ({ graphStats, colors }: Props) => {
+const TrendGraph = ({ graphStats, colors, relativeGrowth }: Props) => {
   const stats = graphStats?.filter(Boolean);
   const chartInstance = useRef(null);
 
@@ -17,7 +18,7 @@ const TrendGraph = ({ graphStats, colors }: Props) => {
     const chartData = { labels: [], datasets: [] };
     stats.filter(Boolean).forEach((graphStat, i) => {
       const dataColor = colors[i].join(',');
-      const groupedData = groupDownloadsByPeriod(graphStat.downloads, 'week');
+      const groupedData = groupDownloadsByPeriod(graphStat.downloads, 'week', relativeGrowth);
 
       if (i === 0) {
         const labels = groupedData.map((periodData) => periodData.period);
@@ -103,7 +104,7 @@ const TrendGraph = ({ graphStats, colors }: Props) => {
           {
             ticks: {
               beginAtZero: true,
-              callback: (value) => Number(value).toLocaleString(),
+              callback: (value) => `${Number(value).toLocaleString()}${relativeGrowth ? ' %' : ''}`,
             },
           },
         ],

--- a/components/_chart/TrendGraphBox.tsx
+++ b/components/_chart/TrendGraphBox.tsx
@@ -6,6 +6,9 @@ import TrendGraph from './TrendGraph';
 
 export const djsToStartDate = (djs) => djs.startOf('week').format('YYYY-MM-DD');
 
+const Categories = ['Downloads', 'Relative Growth'] as const;
+type Category = typeof Categories[number];
+
 const propTypes = {
   packets: PropTypes.arrayOf(PropTypes.object).isRequired,
   colors: PropTypes.arrayOf(PropTypes.array).isRequired,
@@ -14,6 +17,7 @@ const propTypes = {
 
 const TrendGraphBox = ({ packets, colors, packageDownloadData }) => {
   const [startDate, setStartDate] = useState(djsToStartDate(dayjs().subtract(12, 'months')));
+  const [category, setCategory] = useState<Category>('Downloads');
   const endDate = dayjs().subtract(1, 'week').endOf('week').format('YYYY-MM-DD');
 
   const { data: graphStats } = usePackageDownloads(packets, startDate, endDate, packageDownloadData);
@@ -22,8 +26,12 @@ const TrendGraphBox = ({ packets, colors, packageDownloadData }) => {
     setStartDate(e.target.value);
   };
 
+  const handleCategoryChange = (e) => {
+    setCategory(e.target.value);
+  };
+
   const heading = () => {
-    const selectOptionsData = [
+    const selectPeriodOptionsData = [
       ['1 Month', djsToStartDate(dayjs().subtract(1, 'month'))],
       ['3 Months', djsToStartDate(dayjs().subtract(3, 'month'))],
       ['6 Months', djsToStartDate(dayjs().subtract(6, 'month'))],
@@ -32,17 +40,29 @@ const TrendGraphBox = ({ packets, colors, packageDownloadData }) => {
       ['5 Years', djsToStartDate(dayjs().subtract(5, 'year'))],
       ['All time', djsToStartDate(dayjs('2015-01-10'))],
     ];
-    const selectOptions = selectOptionsData.map((option) => (
+    const selectPeriodOptions = selectPeriodOptionsData.map((option) => (
       <option key={option[1]} value={option[1]}>
         {option[0]}
       </option>
     ));
+
+    const selectCategoryOptions = Categories.map((option) => (
+      <option key={option} value={option}>
+        {option}
+      </option>
+    ));
+
     return (
       <h2 className="chart-heading">
-        Downloads <span className="text--light">in past</span>
+        <span className="select-container">
+          <select className="chart-heading-select" value={category} onChange={handleCategoryChange}>
+            {selectCategoryOptions}
+          </select>
+        </span>
+        <span className="text--light"> in past</span>
         <span className="select-container">
           <select className="chart-heading-select" value={startDate} onChange={handlePeriodChange}>
-            {selectOptions}
+            {selectPeriodOptions}
           </select>
         </span>
       </h2>
@@ -52,7 +72,7 @@ const TrendGraphBox = ({ packets, colors, packageDownloadData }) => {
   return (
     <div>
       {heading()}
-      <TrendGraph graphStats={graphStats} colors={colors} />
+      <TrendGraph graphStats={graphStats} colors={colors} relativeGrowth={category === 'Relative Growth'} />
     </div>
   );
 };

--- a/components/_chart/TrendGraphBox.tsx
+++ b/components/_chart/TrendGraphBox.tsx
@@ -6,7 +6,7 @@ import TrendGraph from './TrendGraph';
 
 export const djsToStartDate = (djs) => djs.startOf('week').format('YYYY-MM-DD');
 
-const Categories = ['Downloads', 'Relative Growth'] as const;
+const Categories = ['Downloads', 'Growth'] as const;
 type Category = typeof Categories[number];
 
 const propTypes = {
@@ -72,7 +72,7 @@ const TrendGraphBox = ({ packets, colors, packageDownloadData }) => {
   return (
     <div>
       {heading()}
-      <TrendGraph graphStats={graphStats} colors={colors} relativeGrowth={category === 'Relative Growth'} />
+      <TrendGraph graphStats={graphStats} colors={colors} growth={category === 'Growth'} />
     </div>
   );
 };

--- a/utils/groupDates.ts
+++ b/utils/groupDates.ts
@@ -4,19 +4,35 @@ import dayjs from 'dayjs';
 // dates: [{"day":"2012-10-22","downloads":279},
 //         {"day":"2012-10-23","downloads":2042}]
 // period: 'week'
-export const groupDownloadsByPeriod = (dates, period: 'week' | 'month' | 'year' = 'week') => {
-  const downloadsGroupedByPeriod = {};
+export const groupDownloadsByPeriod = (
+  dates,
+  period: 'week' | 'month' | 'year' = 'week',
+  relative: boolean = false,
+) => {
+  const downloadsGroupedByPeriodRecord: Record<string, number> = {};
 
   dates.forEach((date) => {
     const startOfPeriodDate = dayjs(date.day).startOf(period).format('YYYY-MM-DD');
 
-    downloadsGroupedByPeriod[startOfPeriodDate] = downloadsGroupedByPeriod[startOfPeriodDate]
-      ? downloadsGroupedByPeriod[startOfPeriodDate] + date.downloads
+    downloadsGroupedByPeriodRecord[startOfPeriodDate] = downloadsGroupedByPeriodRecord[startOfPeriodDate]
+      ? downloadsGroupedByPeriodRecord[startOfPeriodDate] + date.downloads
       : date.downloads;
   });
 
-  return Object.entries(downloadsGroupedByPeriod).map(([key, value]) => ({
+  const downloadsGroupedByPeriod = Object.entries(downloadsGroupedByPeriodRecord).map(([key, value]) => ({
     period: dayjs(key).toDate(),
     downloads: value,
   }));
+
+  if (relative) {
+    const initialDownloads = downloadsGroupedByPeriod[0].downloads;
+    const maxDownloads = Math.max(...downloadsGroupedByPeriod.map(({ downloads }) => downloads));
+
+    return downloadsGroupedByPeriod.map(({ period, downloads }) => ({
+      period,
+      downloads: ((downloads - initialDownloads) * 100) / maxDownloads,
+    }));
+  }
+
+  return downloadsGroupedByPeriod;
 };

--- a/utils/groupDates.ts
+++ b/utils/groupDates.ts
@@ -4,11 +4,7 @@ import dayjs from 'dayjs';
 // dates: [{"day":"2012-10-22","downloads":279},
 //         {"day":"2012-10-23","downloads":2042}]
 // period: 'week'
-export const groupDownloadsByPeriod = (
-  dates,
-  period: 'week' | 'month' | 'year' = 'week',
-  relative: boolean = false,
-) => {
+export const groupDownloadsByPeriod = (dates, period: 'week' | 'month' | 'year' = 'week', growth: boolean = false) => {
   const downloadsGroupedByPeriodRecord: Record<string, number> = {};
 
   dates.forEach((date) => {
@@ -24,7 +20,7 @@ export const groupDownloadsByPeriod = (
     downloads: value,
   }));
 
-  if (relative) {
+  if (growth) {
     const initialDownloads = downloadsGroupedByPeriod[0].downloads;
     const maxDownloads = Math.max(...downloadsGroupedByPeriod.map(({ downloads }) => downloads));
 


### PR DESCRIPTION
Closes #28.

Relative growth rate gives crucial insights that can be helpful to both library users and maintainers. For example, if we look into the past 2 years, we can see that swr outran react-query in downloads around Oct 2023. But with the relative growth rate, we can see that swr usage grew faster than react-query from Sep 2022!

![react-query vs swr number of downloads](https://github.com/uidotdev/npm-trends/assets/91976421/269385b9-3c75-4258-8857-91014916a3b1)
![react-query vs swr relative growth rate](https://github.com/uidotdev/npm-trends/assets/91976421/3acc5a5e-cf48-4a41-828e-38f13b2fcc21)

### Is this better than average growth rate #103? (IMO Yes)

Averages are prone to outliers skew. With npm packages, every holiday season sees a sharp decline in downloads(see the picture above, swr downloads dropped almost by half!). Relative growth rate provides a clear view by showing growth across all periods.

@johnmpotter It seems like you'll like this!

@uidotdev @benadam11 Please check this out when you get a chance!