### PR TITLE
Fix: Keep colors while changing packages

### DIFF
--- a/components/PackageComparison/index.tsx
+++ b/components/PackageComparison/index.tsx
@@ -2,7 +2,6 @@ import { useCallback } from 'react';
 import PropTypes from 'prop-types';
 import { useRouter } from 'next/router';
 
-import { colors } from 'utils/colors';
 import { packetNamesToParam } from 'utils/url';
 
 import SearchForm from 'components/_search/SearchForm';
@@ -40,10 +39,10 @@ const PackageComparison = ({ packets, packetNames = [], popularSearches, package
     <div className="container">
       <PackageComparisonHeading packetNames={packetNames} packets={packets} />
       <SearchForm onSearch={updateFromSearch} />
-      <PackageTags packets={packets} colors={colors} />
+      <PackageTags packets={packets} />
       {packets.length > 0 && (
         <div>
-          <TrendGraphBox packageDownloadData={packageDownloadData} packets={packets} colors={colors} />
+          <TrendGraphBox packageDownloadData={packageDownloadData} packets={packets} />
           <PackageStats packets={packets} />
         </div>
       )}

--- a/components/_chart/TrendGraph.tsx
+++ b/components/_chart/TrendGraph.tsx
@@ -6,17 +6,16 @@ import { groupDownloadsByPeriod } from 'utils/groupDates';
 
 type Props = {
   graphStats: any[];
-  colors: number[][];
 };
 
-const TrendGraph = ({ graphStats, colors }: Props) => {
+const TrendGraph = ({ graphStats }: Props) => {
   const stats = graphStats?.filter(Boolean);
   const chartInstance = useRef(null);
 
   const getChartData = useCallback(() => {
     const chartData = { labels: [], datasets: [] };
     stats.filter(Boolean).forEach((graphStat, i) => {
-      const dataColor = colors[i].join(',');
+      const dataColor = graphStat.color.join(',');
       const groupedData = groupDownloadsByPeriod(graphStat.downloads, 'week');
 
       if (i === 0) {
@@ -47,8 +46,7 @@ const TrendGraph = ({ graphStats, colors }: Props) => {
     }, this);
 
     return chartData;
-  }, [stats, colors]);
-
+  }, [stats]);
 
   const getChartOptions = useCallback(() => {
     const firstDateForChartdayjs = dayjs(stats?.[0]?.downloads?.[0]?.day || '2021-06-27');
@@ -83,10 +81,10 @@ const TrendGraph = ({ graphStats, colors }: Props) => {
             if (!data.datasets.length) {
               return [
                 {
-                  text: "loading",
-                  fillStyle: "rgba(0,0,0,0.05)",
+                  text: 'loading',
+                  fillStyle: 'rgba(0,0,0,0.05)',
                   strokeStyle: 'transparent',
-                }
+                },
               ];
             }
 

--- a/components/_chart/TrendGraphBox.tsx
+++ b/components/_chart/TrendGraphBox.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import dayjs from 'dayjs';
 import { usePackageDownloads } from 'services/queries';
@@ -8,11 +8,10 @@ export const djsToStartDate = (djs) => djs.startOf('week').format('YYYY-MM-DD');
 
 const propTypes = {
   packets: PropTypes.arrayOf(PropTypes.object).isRequired,
-  colors: PropTypes.arrayOf(PropTypes.array).isRequired,
   packageDownloadData: PropTypes.arrayOf(PropTypes.object),
 };
 
-const TrendGraphBox = ({ packets, colors, packageDownloadData }) => {
+const TrendGraphBox = ({ packets, packageDownloadData }) => {
   const [startDate, setStartDate] = useState(djsToStartDate(dayjs().subtract(12, 'months')));
   const endDate = dayjs().subtract(1, 'week').endOf('week').format('YYYY-MM-DD');
 
@@ -52,7 +51,7 @@ const TrendGraphBox = ({ packets, colors, packageDownloadData }) => {
   return (
     <div>
       {heading()}
-      <TrendGraph graphStats={graphStats} colors={colors} />
+      <TrendGraph graphStats={graphStats} />
     </div>
   );
 };

--- a/components/_search/PackageTags.tsx
+++ b/components/_search/PackageTags.tsx
@@ -10,10 +10,9 @@ import { Router } from 'next/router';
 
 type Props = {
   packets: IPackage[];
-  colors: number[][];
 };
 
-const PackageTags = ({ packets, colors }: Props) => {
+const PackageTags = ({ packets }: Props) => {
   const packetNamesArray = useMemo(() => packets.map((packet) => packet.name), [packets]);
   const searchQueryParams = queryString.stringify({
     'search_query[]': packetNamesArray,
@@ -37,7 +36,7 @@ const PackageTags = ({ packets, colors }: Props) => {
 
   const renderPackageTags = () =>
     packets.map((packet, i) => {
-      const border = `2px solid rgb(${colors[i].join(',')})`;
+      const border = `2px solid rgb(${packet.color.join(',')})`;
       return (
         <li key={packet.id} className="package-search-tag" style={{ border }}>
           <DetailsPopover packageName={packet.name}>

--- a/pages/[[...packets]].tsx
+++ b/pages/[[...packets]].tsx
@@ -7,6 +7,7 @@ import API from 'services/API';
 import Package from 'services/Package';
 import { getPacketNamesFromQuery, searchPathToDisplayString, getCanonical } from 'utils/url';
 import { hasNavigationCSR } from 'utils/hasNavigationCSR';
+import { getColors } from 'utils/colors';
 
 import AppHead from 'components/_templates/AppHead';
 import Layout from 'components/_templates/Layout';
@@ -63,10 +64,11 @@ export const getServerSideProps = hasNavigationCSR(async ({ query, res, req }) =
   const startDate = djsToStartDate(dayjs().subtract(12, 'months'));
   const endDate = dayjs().subtract(1, 'week').endOf('week').format('YYYY-MM-DD');
 
+  const colors = getColors(packetNames);
   const [pageData, popularSearches, packageDownloadData] = await Promise.all([
     fetchPageData(packetNames),
     Fetch.getJSON('/s/searches?limit=10'),
-    Promise.all(packetNames.map((name) => PackageDownloads.fetchDownloads(name, startDate, endDate))),
+    Promise.all(packetNames.map((name) => PackageDownloads.fetchDownloads(name, colors[name], startDate, endDate))),
   ]);
 
   // If error with any packages, remove errored packages from url

--- a/services/Package.ts
+++ b/services/Package.ts
@@ -2,7 +2,7 @@ import _get from 'lodash/get';
 import hostedGitInfo from 'hosted-git-info';
 
 import { githubReposURL, npmRegistryURL } from 'utils/proxy';
-import { colors } from 'utils/colors';
+import { getColors } from 'utils/colors';
 import IPackage from 'types/IPackage';
 import INpmRegistryDataFormatted from 'types/INpmRegistryDataFormatted';
 import Fetch from './Fetch';
@@ -12,9 +12,10 @@ class Package {
   static fetchPackages = async (packetNames: string[]): Promise<{ validPackages: IPackage[] }> => {
     // packageNames format: ['react', '@angular-core']
     const pkgs = await Promise.allSettled(packetNames.map((name) => Package.fetchPackage(name)));
+    const colors = getColors(packetNames);
     const validPackages = pkgs.reduce((acc, pkg, i) => {
       if (pkg.status === 'fulfilled') {
-        acc.push({ ...pkg.value, color: colors[i] });
+        acc.push({ ...pkg.value, color: colors[pkg.value.name] });
       }
       return acc;
     }, []);
@@ -51,7 +52,6 @@ class Package {
     if (registry?.repository?.url?.includes('github')) {
       github = await Package.fetchGithubRepo(registry.repository.url);
     }
-
 
     return {
       ...registry,

--- a/services/PackageDownloads.ts
+++ b/services/PackageDownloads.ts
@@ -3,10 +3,10 @@ import duration from 'dayjs/plugin/duration';
 import { npmDownloadsURL } from 'utils/proxy';
 import Fetch from './Fetch';
 
-dayjs.extend(duration)
+dayjs.extend(duration);
 
 class PackageDownloads {
-  static fetchDownloads = async (packageName, startDate, endDate) => {
+  static fetchDownloads = async (packageName, packageColor, startDate, endDate) => {
     const startDjs = dayjs(startDate);
     const endDjs = dayjs(endDate);
 
@@ -38,6 +38,7 @@ class PackageDownloads {
 
     return {
       package: packageName,
+      color: packageColor,
       downloads: fetchedDownloads.reduce((acc, val) => acc.concat(val.downloads), []),
     };
   };

--- a/services/queries/index.ts
+++ b/services/queries/index.ts
@@ -83,7 +83,8 @@ export function useSearchPackages(searchQuery: string) {
 export function usePackageDownloads(packets: IPackage[], startDate: string, endDate: string, initialData = []) {
   return useQuery(
     ['package-downloads', { startDate, endDate, packets }],
-    () => Promise.all(packets.map(({ name }) => PackageDownloads.fetchDownloads(name, startDate, endDate))),
+    () =>
+      Promise.all(packets.map(({ name, color }) => PackageDownloads.fetchDownloads(name, color, startDate, endDate))),
     {
       initialData,
       keepPreviousData: true,

--- a/utils/colors.ts
+++ b/utils/colors.ts
@@ -1,4 +1,4 @@
-export const colors = [
+const colors = [
   [0, 116, 217],
   [255, 133, 27],
   [46, 204, 64],
@@ -10,3 +10,26 @@ export const colors = [
   [0, 31, 63],
   [1, 255, 112],
 ];
+
+const packageColorRecord: Record<string, number[]> = {};
+
+export function getColors(packageNames: string[]): typeof packageColorRecord {
+  Object.keys(packageColorRecord).forEach((packageName) => {
+    if (!packageNames.includes(packageName)) {
+      delete packageColorRecord[packageName];
+    }
+  });
+
+  const unusedColorsSet = new Set(colors.map((color) => color.join(',')));
+  Object.values(packageColorRecord).forEach((color) => unusedColorsSet.delete(color.join(',')));
+  const unusedColors = Array.from(unusedColorsSet.values()).map((color) => color.split(',').map(Number));
+  let index = 0;
+  packageNames.forEach((packageName) => {
+    if (!packageColorRecord[packageName]) {
+      packageColorRecord[packageName] = unusedColors[index];
+      index++;
+    }
+  });
+
+  return packageColorRecord;
+}


### PR DESCRIPTION
Fixes #159

* Use a record to store package names -> color mapping
* Add the color to use for a package in its data and use it in all components


https://github.com/uidotdev/npm-trends/assets/91976421/06592c5c-7738-4ec1-923b-e2a1fd29283b

> [!NOTE]
> Does not remember colors of removed packages